### PR TITLE
Bugfix #33 - Validação de e-mail no cadastro

### DIFF
--- a/cypress/e2e/us02-signup.cy.js
+++ b/cypress/e2e/us02-signup.cy.js
@@ -34,4 +34,17 @@ describe('US02 - Cadastro de usuário', () => {
     cy.get('#feedback-close').click();
     cy.get('#feedback-modal').should('not.be.visible');
   });
+
+  it('impede cadastro com e-mail em formato inválido', () => {
+    cy.visit('/');
+
+    cy.get('#signup-name').type('Luke Skywalker');
+    cy.get('#signup-email').type('luke@jedi');
+    cy.get('#signup-password').type('123456');
+    cy.get('#signup-form button[type="submit"]').click();
+
+    cy.get('#feedback-modal').should('be.visible');
+    cy.contains('Seu cadastro não pôde ser concluído.').should('be.visible');
+    cy.contains('E-mail em formato inválido.').should('be.visible');
+  });
 });

--- a/public/index.html
+++ b/public/index.html
@@ -81,7 +81,7 @@
               </p>
             </div>
 
-            <form id="signup-form" class="signup-card">
+            <form id="signup-form" class="signup-card" novalidate>
               <label>
                 Nome
                 <input id="signup-name" type="text" placeholder="Seu nome" />
@@ -108,7 +108,7 @@
               </p>
             </div>
 
-            <form id="login-form" class="login-card">
+            <form id="login-form" class="login-card" novalidate>
               <label>
                 E-mail
                 <input id="email" type="email" value="usuario@receitasdavo.com" />

--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -5,9 +5,17 @@ function sanitizeUser(user) {
   return safeUser;
 }
 
+function isValidEmail(email) {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+}
+
 function registerUser({ name, email, password }) {
   if (!name || !email || !password) {
     return { status: 400, body: { message: 'Nome, e-mail e senha são obrigatórios.' } };
+  }
+
+  if (!isValidEmail(email)) {
+    return { status: 400, body: { message: 'E-mail em formato inválido.' } };
   }
 
   const database = readDatabase();
@@ -71,6 +79,7 @@ function getAuthenticatedUser(authorizationHeader) {
 
 module.exports = {
   getAuthenticatedUser,
+  isValidEmail,
   loginUser,
   registerUser,
   sanitizeUser

--- a/tests/api/auth.test.js
+++ b/tests/api/auth.test.js
@@ -22,6 +22,19 @@ describe('API - Autenticação', () => {
     expect(response.body.user).to.not.have.property('password');
   });
 
+  it('bloqueia cadastro com e-mail em formato inválido', async () => {
+    const response = await request(app)
+      .post('/api/auth/register')
+      .send({
+        name: 'Luke Skywalker',
+        email: 'luke@jedi',
+        password: '123456'
+      });
+
+    expect(response.status).to.equal(400);
+    expect(response.body.message).to.equal('E-mail em formato inválido.');
+  });
+
   it('bloqueia cadastro com e-mail já cadastrado', async () => {
     const response = await request(app)
       .post('/api/auth/register')


### PR DESCRIPTION
## Objetivo
Corrigir o bug HugoTorquetti/api-portifolio-pessoal-mentoria#75 para impedir o cadastro com e-mail sem domínio de topo válido.

## O que foi corrigido
- validação de formato de e-mail no backend antes da criação do usuário
- mensagem de erro padronizada para e-mail inválido
- ajuste do formulário de cadastro para permitir que o sistema exiba o feedback via modal
- testes de API para cenário de e-mail inválido
- teste E2E para cadastro com e-mail em formato inválido

## Validações executadas
- npm.cmd test
- npm.cmd run test:e2e

## Bug relacionado
- corrige HugoTorquetti/api-portifolio-pessoal-mentoria#75